### PR TITLE
Suggestion for a C++ wrapper.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ option(BUILD_TESTS "Build the test programs." OFF)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/common")
 
+add_definitions("-Wall -Werror -pedantic" ${MPI_C_COMPILE_FLAGS} ${MPI_C_LINK_FLAGS})
+
 if(BUILD_LIBRARY)
     find_package(HDEEM REQUIRED)
     find_package(FreeIPMI REQUIRED)
@@ -40,16 +42,20 @@ if(BUILD_LIBRARY)
 
     set(PHDEEM_SOURCE_FILES "${PROJECT_SOURCE_DIR}/src/phdeem.c" "${PROJECT_SOURCE_DIR}/src/phdeem.h")
 
-    add_definitions("-Wall -Werror -pedantic -ansi -std=gnu99" ${MPI_C_COMPILE_FLAGS} ${MPI_C_LINK_FLAGS})
     include_directories(SYSTEM ${HDEEM_INCLUDE_DIRS} ${FreeIPMI_INCLUDE_DIRS} ${MPI_C_INCLUDE_PATH})
     add_library(${PROJECT_NAME} SHARED ${PHDEEM_SOURCE_FILES})
+    set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-std=gnu99")
     target_link_libraries(${PROJECT_NAME} ${HDEEM_LIBRARIES} ${FreeIPMI_LIBRARIES} ${MPI_C_LIBRARIES})
 endif()
 
 if(BUILD_EXAMPLES)
-    include_directories("src/" SYSTEM ${HDEEM_INCLUDE_DIRS} ${FreeIPMI_INCLUDE_DIRS} ${MPI_C_INCLUDE_PATH})
-    add_executable("full_example" "examples/full_example.c")
+    include_directories("${PROJECT_SOURCE_DIR}/src/" SYSTEM ${HDEEM_INCLUDE_DIRS} ${FreeIPMI_INCLUDE_DIRS} ${MPI_C_INCLUDE_PATH})
+    add_executable("full_example" "${PROJECT_SOURCE_DIR}/examples/full_example.c")
+    set_target_properties("full_example" PROPERTIES COMPILE_FLAGS "-std=gnu99")
     target_link_libraries("full_example" ${PROJECT_NAME})
+    add_executable("cpp_example" "${PROJECT_SOURCE_DIR}/examples/cpp_example.cpp")
+    set_target_properties("cpp_example" PROPERTIES COMPILE_FLAGS "-std=c++11" ${MPI_COMPILE_FLAGS})
+    target_link_libraries("cpp_example" ${PROJECT_NAME} ${MPI_CXX_LIBRARIES})
 endif()
 
 if(BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ To compile this plugin, you need:
 
 * FreeIPMI
 
+For building the examples you'll additionally need:
+
+* A C++ 11 compatible compiler
+
 ###Building
 
 1. Create a build directory
@@ -52,6 +56,8 @@ To compile this plugin, you need:
 
 ##Usage
 
+###C-interface
+
 The usage of *phdeem* is just the same as the usage of `libhdeem`. You just have to replace the
 `hdeem_` in the function names with `phdeem_` and provide some additional parameters:
 
@@ -87,6 +93,24 @@ The return values of the functions tell you if either
     corresponding return values in `ret_val`).
 
 For more information take a look at the comments in the header file or the examples.
+
+###C++-interface
+
+The usage of *cpphdeem* is slightly different from the usage of the C-interface and hdeem itself as
+you don't need to pass arguments to the function calls. These are handled internally and if you need
+to access their values you have to use the appropriate getter methods.
+
+Otherwise the usage of *cpphdeem* is similar to the usage of the 'blank' hdeem library. After
+calling the constructor of the `connection` class, you can call it's methods just as you would call
+hdeem functions (but without the parameters).
+
+> *Note:*
+
+> Clean-up tasks are **not** implicitly done in the destructor of the `connection` class to give
+> you the maximum freedom in terms of usage. You have to explicitly call functions like `stop` and
+> `clear` (corresponding to `hdeem_stop` and `hdeem_clear`) at the right points in your program.
+
+
 
 > *Note:*
 

--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -1,3 +1,31 @@
+/**
+  Copyright (c) 2016, Technische Universität Dresden, Germany
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, are permitted
+  provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+     and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+     conditions and the following disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific prior written
+     permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <iostream>
 #include <mpi.h>
 #include <unistd.h>

--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -64,7 +64,7 @@ int main( int argc, char** argv )
             auto data = conn.get_hdeem_data( );
             auto readings = conn.get_hdeem_global( );
 
-            std::cout << "Node: " << data.name_blade_sensors[0]
+            std::cout << "Node: " << data.name_blade_sensors[0] << " "
                       << "Number of samples:" << readings.nb_blade_values
                       << std::endl;
         }

--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -1,4 +1,6 @@
+#include <iostream>
 #include <mpi.h>
+#include <unistd.h>
 
 #include "cpphdeem.hpp"
 
@@ -20,7 +22,15 @@ int main( int argc, char** argv )
     // If we're not root, we don't need to call the following functions
     if( conn.root( ) )
     {
-        
+        conn.start( );
+        conn.get_global( );
+        usleep( 100000 );
+        conn.get_global( );
+        auto data = conn.get_hdeem_global( );
+
+        std::cout << "Number of samples:" << data.nb_blade_values << std::endl;
+
+        conn.stop( );
     }
 
     MPI_Finalize( );

--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -22,17 +22,31 @@ int main( int argc, char** argv )
     // If we're not root, we don't need to call the following functions
     if( conn.root( ) )
     {
+        // Start measurement
         conn.start( );
-        conn.get_global( );
-        usleep( 100000 );
-        conn.get_global( );
-        auto data = conn.get_hdeem_global( );
 
-        std::cout << "Number of samples:" << data.nb_blade_values << std::endl;
+        for( int i = 0; i <= 2; ++i )
+        {
+            // Wait a little for data to accumulate
+            usleep( 1000000 );
 
+            // Read data
+            conn.get_global( );
+
+            auto data = conn.get_hdeem_data( );
+            auto readings = conn.get_hdeem_global( );
+
+            std::cout << "Node: " << data.name_blade_sensors[0]
+                      << "Number of samples:" << readings.nb_blade_values
+                      << std::endl;
+        }
+
+        // Finalize the connection
         conn.stop( );
+        conn.clear( );
     }
 
+    // Finalize MPI
     MPI_Finalize( );
 
     return 0;

--- a/examples/cpp_example.cpp
+++ b/examples/cpp_example.cpp
@@ -1,0 +1,29 @@
+#include <mpi.h>
+
+#include "cpphdeem.hpp"
+
+int main( int argc, char** argv )
+{
+    // Initializing MPI
+    MPI_Init( &argc, &argv );
+
+    int world_rank, name_len;
+    char processor_name[MPI_MAX_PROCESSOR_NAME];
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+    MPI_Get_processor_name(processor_name, &name_len);
+
+    // Use the C++ interface
+    cpphdeem::connection conn;
+    conn.init( MPI_COMM_WORLD );
+
+    // If we're not root, we don't need to call the following functions
+    if( conn.root( ) )
+    {
+        
+    }
+
+    MPI_Finalize( );
+
+    return 0;
+}

--- a/examples/full_example.c
+++ b/examples/full_example.c
@@ -77,7 +77,7 @@ int main( int argc, char** argv )
             printf( "'get_global'   from processor %s, global rank %d. Return value was %d\n",
                     processor_name, world_rank, ret );
 
-            printf( "\n%s, read %llu values\n--------------\n", hdeem_data.name_blade_sensors[0],
+            printf( "\n%s, read %lu values\n--------------\n", hdeem_data.name_blade_sensors[0],
                     readings.nb_blade_values);
 
             sleep(1);

--- a/examples/full_example.c
+++ b/examples/full_example.c
@@ -77,7 +77,7 @@ int main( int argc, char** argv )
             printf( "'get_global'   from processor %s, global rank %d. Return value was %d\n",
                     processor_name, world_rank, ret );
 
-            printf( "\n%s, read %lu values\n--------------\n", hdeem_data.name_blade_sensors[0],
+            printf( "\n%s, read %llu values\n--------------\n", hdeem_data.name_blade_sensors[0],
                     readings.nb_blade_values);
 
             sleep(1);

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <mpi.h>
 #include <cstdint>
+#include <mpi.h>
+#include <stdexcept>
 
 extern "C"
 {
@@ -28,8 +29,8 @@ namespace cpphdeem
     {
     public:
         connection( )
-        : m_root( false ), hdeem_data( ), hdeem_global( ), hdeem_stats( ), internal_status( ),
-          return_values( )
+        : m_root( false ), hdeem_data( ), hdeem_global( ), hdeem_stats_reading( ), hdeem_stats( ),
+          internal_status( ), return_values( )
         { }
 
         ~connection( )
@@ -87,6 +88,35 @@ namespace cpphdeem
                                                          &return_values ) );
         }
 
+        phdeem_return_value get_stats( )
+        {
+            return map_to_enum_class( phdeem_get_stats( &hdeem_data,
+                                                        &hdeem_stats_reading,
+                                                        &internal_status,
+                                                        &return_values ) );
+        }
+
+        phdeem_return_value data_free( )
+        {
+            return map_to_enum_class( phdeem_data_free( &hdeem_global,
+                                                        &internal_status,
+                                                        &return_values ) );
+        }
+
+        phdeem_return_value stats_free( )
+        {
+            return map_to_enum_class( phdeem_stats_free( &hdeem_stats_reading,
+                                                         &internal_status,
+                                                         &return_values ) );
+        }
+
+        phdeem_return_value clear( )
+        {
+            return map_to_enum_class( phdeem_clear( &hdeem_data,
+                                                    &internal_status,
+                                                    &return_values ) );
+        }
+
         inline bool root( ) const
         {
             return m_root;
@@ -100,6 +130,11 @@ namespace cpphdeem
         hdeem_global_reading_t get_hdeem_global( ) const
         {
             return hdeem_global;
+        }
+
+        hdeem_stats_reading_t get_hdeem_stats_reading( ) const
+        {
+            return hdeem_stats_reading;
         }
 
         hdeem_status_t get_hdeem_status( ) const
@@ -124,8 +159,10 @@ namespace cpphdeem
                 case 2:
                     return phdeem_return_value::HDEEM_ERROR;
                 case 3:
-                default:
                     return phdeem_return_value::MPI_ERROR;
+                default:
+                    throw std::invalid_argument( "cpphdeem: Unrecognized return value in "
+                                                 "'map_to_enum_class'" );
             }
         }
 
@@ -133,6 +170,7 @@ namespace cpphdeem
 
         hdeem_bmc_data_t hdeem_data;
         hdeem_global_reading_t hdeem_global;
+        hdeem_stats_reading_t hdeem_stats_reading;
         hdeem_status_t hdeem_stats;
         phdeem_info_t internal_status;
         phdeem_status_t return_values;

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <mpi.h>
+#include <cstdint>
+
+extern "C"
+{
+#include "hdeem.h"
+#include "phdeem.h"
+}
+
+namespace cpphdeem
+{
+    /**
+     * Stores the return values from phdeem.
+     * 
+     * This is just a type safe mapping from the original phdeem_return_values.
+     */
+    enum class phdeem_return_value : std::uint8_t
+    {
+        SUCCESS,
+        NOT_ROOT,
+        HDEEM_ERROR,
+        MPI_ERROR,
+    };
+
+    class connection
+    {
+    public:
+        connection( )
+        : m_root( false ), hdeem_data( ), internal_status( ), return_values( )
+        { }
+
+        ~connection( )
+        { }
+
+        phdeem_return_value init( MPI_Comm current_comm )
+        {
+            phdeem_return_value ret = map_to_enum_class( phdeem_init( &hdeem_data,
+                                                                      &internal_status,
+                                                                      current_comm,
+                                                                      &return_values ) );
+
+            if( ret != phdeem_return_value::NOT_ROOT )
+            {
+                m_root = true;
+            }
+
+            return ret;
+        }
+
+        phdeem_return_value close( )
+        {
+            return map_to_enum_class( phdeem_close( &hdeem_data,
+                                                    &internal_status,
+                                                    &return_values ) );
+        }
+
+        inline bool root( ) const
+        {
+            return m_root;
+        }
+
+        hdeem_bmc_data_t& get_hdeem_data( )
+        {
+            return hdeem_data;
+        }
+
+        phdeem_status_t get_return_values( ) const
+        {
+            return return_values;
+        }
+
+    private:
+        inline phdeem_return_value map_to_enum_class( int ret_val ) const
+        {
+            switch( ret_val )
+            {
+                case 0:
+                    return phdeem_return_value::SUCCESS;
+                case 1:
+                    return phdeem_return_value::NOT_ROOT;
+                case 2:
+                    return phdeem_return_value::HDEEM_ERROR;
+                case 3:
+                default:
+                    return phdeem_return_value::MPI_ERROR;
+            }
+        }
+
+        bool m_root;
+
+        hdeem_bmc_data_t hdeem_data;
+        phdeem_info_t internal_status;
+        phdeem_status_t return_values;
+    };
+}

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -53,6 +53,9 @@ namespace cpphdeem
         MPI_ERROR,
     };
 
+    /**
+     * MPI enabled C++ interface for hdeem
+     */
     class connection
     {
     public:
@@ -176,6 +179,14 @@ namespace cpphdeem
         }
 
     private:
+        /**
+         * Deletes the default copy constructor.
+         * 
+         * I can't think of any use case for the copy constructor right now, so I delete it. If you
+         * need it, please let me know and I'll implement a proper one.
+         */
+        connection( const connection& rhs ) = delete;
+
         inline phdeem_return_value map_to_enum_class( int ret_val ) const
         {
             switch( ret_val )

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -54,7 +54,11 @@ namespace cpphdeem
     };
 
     /**
-     * MPI enabled C++ interface for hdeem
+     * MPI enabled C++ interface for hdeem.
+     * 
+     * After calling the constructor, just use the methods of the class as you would use the 
+     * original hdeem functions. Parameters are handled internally, if you need to access their
+     * values, use the appropriate getter functions.
      */
     class connection
     {
@@ -187,6 +191,9 @@ namespace cpphdeem
          */
         connection( const connection& rhs ) = delete;
 
+        /**
+         * Maps the untyped return values from phdeem to the type-safe enum class.
+         */
         inline phdeem_return_value map_to_enum_class( int ret_val ) const
         {
             switch( ret_val )

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -1,3 +1,31 @@
+/**
+  Copyright (c) 2016, Technische Universität Dresden, Germany
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, are permitted
+  provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this list of conditions
+     and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice, this list of
+     conditions and the following disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+  3. Neither the name of the copyright holder nor the names of its contributors may be used to
+     endorse or promote products derived from this software without specific prior written
+     permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #pragma once
 
 #include <cstdint>

--- a/src/cpphdeem.hpp
+++ b/src/cpphdeem.hpp
@@ -28,7 +28,8 @@ namespace cpphdeem
     {
     public:
         connection( )
-        : m_root( false ), hdeem_data( ), internal_status( ), return_values( )
+        : m_root( false ), hdeem_data( ), hdeem_global( ), hdeem_stats( ), internal_status( ),
+          return_values( )
         { }
 
         ~connection( )
@@ -56,6 +57,36 @@ namespace cpphdeem
                                                     &return_values ) );
         }
 
+        phdeem_return_value start( )
+        {
+            return map_to_enum_class( phdeem_start( &hdeem_data,
+                                                    &internal_status,
+                                                    &return_values ) );
+        }
+
+        phdeem_return_value stop( )
+        {
+            return map_to_enum_class( phdeem_stop( &hdeem_data,
+                                                   &internal_status,
+                                                   &return_values ) );
+        }
+
+        phdeem_return_value check_status( )
+        {
+            return map_to_enum_class( phdeem_check_status( &hdeem_data,
+                                                           &hdeem_stats,
+                                                           &internal_status,
+                                                           &return_values ) );
+        }
+
+        phdeem_return_value get_global( )
+        {
+            return map_to_enum_class( phdeem_get_global( &hdeem_data,
+                                                         &hdeem_global,
+                                                         &internal_status,
+                                                         &return_values ) );
+        }
+
         inline bool root( ) const
         {
             return m_root;
@@ -64,6 +95,16 @@ namespace cpphdeem
         hdeem_bmc_data_t& get_hdeem_data( )
         {
             return hdeem_data;
+        }
+
+        hdeem_global_reading_t get_hdeem_global( ) const
+        {
+            return hdeem_global;
+        }
+
+        hdeem_status_t get_hdeem_status( ) const
+        {
+            return hdeem_stats;
         }
 
         phdeem_status_t get_return_values( ) const
@@ -91,6 +132,8 @@ namespace cpphdeem
         bool m_root;
 
         hdeem_bmc_data_t hdeem_data;
+        hdeem_global_reading_t hdeem_global;
+        hdeem_status_t hdeem_stats;
         phdeem_info_t internal_status;
         phdeem_status_t return_values;
     };


### PR DESCRIPTION
This is my suggestion for a C++ wrapper around _phdeem_, called _cpphdeem_. The idea is that you create an instance of the `connection` class and afterwards call it's methods just like you would have called the corresponding hdeem functions.

Some thoughts about my implementation:
- I tried to map the hdeem functions 1 to 1 in the `connection` class. This is probably the easiest way for end-users when switching from blank hdeem to _cpphdeem_.
- I handle the parameters internally. This makes function calls a lot shorter and you don't have to bother about the right order. For the most function calls you're probably not interested in the values of the parameters, you just pass them as the status (typical C-API). When you're interested in their values, you can use the getter functions.
- I thought about implementing the `connection` class as a singleton but came to the conclusion that this would probably be over-the-top.

Please give me some feedback and share your opinion with me.
